### PR TITLE
Makefile.PL: Exit with failure on missing DBI

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -57,7 +57,7 @@ eval {
 };
 if ( $@ or DBI->VERSION < $DBI_required ) {
 	print "DBI 1.57 is required to configure this module; please install it or upgrade your CPAN/CPANPLUS shell.\n";
-	exit(0);
+	exit(1);
 }
 
 # See if we have a C compiler
@@ -106,7 +106,7 @@ SCOPE: {
 
 	unless ( can_cc() ) {
 		print "We can't locate a C compiler from your Config.pm.\n";
-		exit(0);
+		exit(1);
 	}
 }
 


### PR DESCRIPTION
When DBI is missing or its version isn't sufficient, DBD::SQLite exits with 0. This causes some packaging systems to not perceive any errors and continue, even though no Makefile has been generated. This was an issue when trying to package it for openembedded.

Edit: Found that this was the case also for missing c compiler. Updated the patch.

Regards,
/Olof
