### PR TITLE
Fix version check against 3.7.11 so the test runs

### DIFF
--- a/t/59_extended_result_codes.t
+++ b/t/59_extended_result_codes.t
@@ -12,7 +12,7 @@ use DBD::SQLite;
 
 BEGIN{
     plan skip_all => 'this test is for Win32 only' unless $^O eq 'MSWin32';
-    plan skip_all => 'this test requires SQLite 3.7.12 and above' unless $DBD::SQLite::sqlite_version_number > 3071100;
+    plan skip_all => 'this test requires SQLite 3.7.12 and above' unless $DBD::SQLite::sqlite_version_number > 3007011;
 }
 
 use Test::NoWarnings;


### PR DESCRIPTION
A typo in the version number in `t/59_extended_result_codes.t` causes test to be skipped. In the test file, 3.7.11 is encoded as `3071100`. The correct construction is `3007011`.

See also https://www.nu42.com/2015/11/tests-never-ran.html