### PR TITLE
Fix statistics_info when only unique indexes were requested

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Changes for Perl extension DBD-SQLite
 
+    - Fixed statistics_info when only unique indexes were requested (Dave
+      Rolsky++). GitHub #21
+
 1.55 2017-01-04
     - Updated SQLite to 3.16.0
 

--- a/lib/DBD/SQLite.pm
+++ b/lib/DBD/SQLite.pm
@@ -679,7 +679,7 @@ sub statistics_info {
             $sth->execute or return;
             while(my $row = $sth->fetchrow_hashref) {
 
-                next if defined $unique_only && $unique_only && $row->{unique};
+                next if $unique_only && !$row->{unique};
                 my $quoted_idx = $dbh->quote_identifier($row->{name});
                 for my $db (@$databases) {
                     my $quoted_db = $dbh->quote_identifier($db->{name});

--- a/t/55_statistics_info.t
+++ b/t/55_statistics_info.t
@@ -46,7 +46,7 @@ CREATE TABLE remote.b (
 __EOSQL__
 
 
-plan tests => @sql_statements + 33;
+plan tests => @sql_statements + 48;
 
 my $dbh = connect_ok( RaiseError => 1, PrintError => 0, AutoCommit => 1 );
 my $sth;
@@ -78,6 +78,29 @@ for ($stats_data->{a_ln}->{1}) {
   is($_->{TABLE_SCHEM}, "main",           "table schema");
 }
 ok(not(exists $stats_data->{a_ln}->{2}), "only one index in a_ln index");
+for ($stats_data->{a_an}->{1}) {
+  is($_->{TABLE_NAME},  "a"  ,   "table name");
+  is($_->{COLUMN_NAME}, "fname",   "column name");
+  is($_->{TYPE},        "btree",           "type");
+  is($_->{ORDINAL_POSITION}, 1,           "ordinal position");
+  is($_->{NON_UNIQUE}, 0,           "non unique");
+  is($_->{INDEX_NAME}, "a_an",           "index name");
+  is($_->{TABLE_SCHEM}, "main",           "table schema");
+}
+for ($stats_data->{a_an}->{2}) {
+  is($_->{TABLE_NAME},  "a"  ,   "table name");
+  is($_->{COLUMN_NAME}, "lname",   "column name");
+  is($_->{TYPE},        "btree",           "type");
+  is($_->{ORDINAL_POSITION}, 2,           "ordinal position");
+  is($_->{NON_UNIQUE}, 0,           "non unique");
+  is($_->{INDEX_NAME}, "a_an",           "index name");
+  is($_->{TABLE_SCHEM}, "main",           "table schema");
+}
+ok(not(exists $stats_data->{a_ln}->{3}), "only two indexes in a_an index");
+
+$sth = $dbh->statistics_info(undef, undef, 'a', 'unique only', 0);
+$stats_data = $sth->fetchall_hashref([ 'INDEX_NAME', 'ORDINAL_POSITION' ]);
+
 for ($stats_data->{a_an}->{1}) {
   is($_->{TABLE_NAME},  "a"  ,   "table name");
   is($_->{COLUMN_NAME}, "fname",   "column name");


### PR DESCRIPTION
This was completely broken before. Now there's a test so it should stay
working.