### PR TITLE
Silence some warnings

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -642,7 +642,7 @@ sqlite_db_disconnect(SV *dbh, imp_dbh_t *imp_dbh)
     sqlite_trace( dbh, imp_dbh, 1, form("rc = %d", rc) );
     if ( SQLITE_BUSY == rc ) { /* We have unfinalized statements */
         /* Only close the statements that were prepared by this module */
-        while ( s = imp_dbh->stmt_list ) {
+        while ( (s = imp_dbh->stmt_list) ) {
             sqlite_trace( dbh, imp_dbh, 1, form("Finalizing statement (%p)", s->stmt) );
             sqlite3_finalize( s->stmt );
             imp_dbh->stmt_list = s->prev;
@@ -657,7 +657,7 @@ sqlite_db_disconnect(SV *dbh, imp_dbh_t *imp_dbh)
     }
     /* The list should be empty at this point, but if for some unforseen reason
        it isn't, free remaining nodes here */
-    while( s = imp_dbh->stmt_list ) {
+    while( (s = imp_dbh->stmt_list) ) {
         imp_dbh->stmt_list = s->prev;
         sqlite3_free( s );
     }
@@ -871,7 +871,7 @@ sqlite_st_prepare_sv(SV *sth, imp_sth_t *imp_sth, SV *sv_statement, SV *attribs)
         }
         return FALSE; /* -> undef in lib/DBD/SQLite.pm */
     }
-    if (&extra && imp_dbh->allow_multiple_statements) {
+    if (imp_dbh->allow_multiple_statements) {
         imp_sth->unprepared_statements = savepv(extra);
     }
     else {


### PR DESCRIPTION
This PR addresses the following warnings:

```
xcrun -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/ clang -c  -I. -I/Users/jacquesg/dev/clang-64/perl-build/cpan/perl/
install/perl/vendor/lib/darwin/auto/DBI -DPERL_RELOCATABLE_INCPUSH -fexceptions -fexceptions -pipe -arch x86_64 -maes -msse2 -mmacosx-version-min=10.12 -isystem/Applications/Xcod
e.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk//usr/include -D_REENTRANT -DPERL_USE_SAFE_PUTENV -fno-strict-aliasing -fstack-protector-strong -
O3 -g   -DVERSION=\"1.54\" -DXS_VERSION=\"1.54\"  "-I/Users/jacquesg/dev/clang-64/perl-build/cpan/perl/install/perl/lib/darwin/CORE"  -DSQLITE_ENABLE_FTS4 -DSQLITE_ENABLE_FTS3_PA
RENTHESIS -DSQLITE_ENABLE_RTREE -DSQLITE_ENABLE_COLUMN_METADATA -DSQLITE_ENABLE_STAT3 -DSQLITE_ENABLE_STAT4 -DSQLITE_ENABLE_JSON1 -DSQLITE_ENABLE_FTS5 -DNDEBUG=1 -DHAVE_USLEEP=1
-DSQLITE_ENABLE_LOCKING_STYLE=0 dbdimp.c
dbdimp.c:645:19: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
        while ( s = imp_dbh->stmt_list ) {
                ~~^~~~~~~~~~~~~~~~~~~~
dbdimp.c:645:19: note: place parentheses around the assignment to silence this warning
        while ( s = imp_dbh->stmt_list ) {
                  ^
                (                     )
dbdimp.c:645:19: note: use '==' to turn this assignment into an equality comparison
        while ( s = imp_dbh->stmt_list ) {
                  ^
                  ==
dbdimp.c:660:14: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
    while( s = imp_dbh->stmt_list ) {
           ~~^~~~~~~~~~~~~~~~~~~~
dbdimp.c:660:14: note: place parentheses around the assignment to silence this warning
    while( s = imp_dbh->stmt_list ) {
             ^
           (                     )
dbdimp.c:660:14: note: use '==' to turn this assignment into an equality comparison
    while( s = imp_dbh->stmt_list ) {
             ^
             ==
dbdimp.c:874:10: warning: address of 'extra' will always evaluate to 'true' [-Wpointer-bool-conversion]
    if (&extra && imp_dbh->allow_multiple_statements) {
         ^~~~~ ~~
3 warnings generated.
```