### PR TITLE
Support SQLite patch releases with four-part version numbers

### DIFF
--- a/t/11_get_info.t
+++ b/t/11_get_info.t
@@ -26,7 +26,7 @@ my %info = (
     SQL_DATA_SOURCE_READ_ONLY  => 'N',
     SQL_DATABASE_NAME          => 'main',
     SQL_DBMS_NAME              => 'SQLite',
-    SQL_DBMS_VER               => qr/^[1-9]+\.\d+\.\d+$/,
+    SQL_DBMS_VER               => qr/^[1-9]+\.\d+\.\d+(\.\d+)?$/,
 
     SQL_IDENTIFIER_QUOTE_CHAR  => '"',
 


### PR DESCRIPTION
The t/11_get_info.t test assumes that the underlying SQLite library has a 3-part version number such as 3.26.0 but a system version of SQLite that is a patch release such as 3.8.4.3 could have been used, which would fail.
This PR adjusts the test to expect 3-part or 4-part version numbers.