### PR TITLE
use SQLITE_STATIC instead of SQLITE_TRANSIENT in execute()

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -954,7 +954,7 @@ sqlite_st_execute(SV *sth, imp_sth_t *imp_sth)
         else if (sql_type == SQLITE_BLOB) {
             STRLEN len;
             char * data = SvPVbyte(value, len);
-            rc = sqlite3_bind_blob(imp_sth->stmt, i+1, data, len, SQLITE_TRANSIENT);
+            rc = sqlite3_bind_blob(imp_sth->stmt, i+1, data, len, SQLITE_STATIC);
         }
         else {
             STRLEN len;
@@ -1003,7 +1003,7 @@ sqlite_st_execute(SV *sth, imp_sth_t *imp_sth)
                             (sql_type == SQLITE_INTEGER ? "integer" : "float")
                         );
                 }
-                rc = sqlite3_bind_text(imp_sth->stmt, i+1, data, len, SQLITE_TRANSIENT);
+                rc = sqlite3_bind_text(imp_sth->stmt, i+1, data, len, SQLITE_STATIC);
             }
         }
 


### PR DESCRIPTION
This makes execute() a little bit faster, because SQLite no longer has to copy binded params.

Dan Kennedy (one of the SQLite developers) has confirmed in a [mailing list post](https://www.mail-archive.com/sqlite-users@mailinglists.sqlite.org/msg26903.html) that `SQLITE_STATIC` can be used in our scenario:

```
On Fri, 2007-08-10 at 11:28 +0200, Jef Driesen wrote:
> When using sqlite3_bind_text() (or a similar function) with 
> SQLITE_STATIC, how long does the pointer have to remain valid? As long 
> as the sqlite3_stmt is not finalized?

Pretty much. It has to be valid during all subsequent calls to 
sqlite3_step() on the statement handle. Or until you bind a
different value to the same parameter.
```

Here are the results of a benchmark from my win32 machine:
```
use strict;
use warnings;

use DBI;
use Benchmark qw/timethese/;

system("del test.sqlite 2>nul");

my $dbh = DBI->connect("dbi:SQLite:dbname=test.sqlite","","", { RaiseError=>1 });
$dbh->do('CREATE TABLE foo ( col TEXT )');

timethese(200000, {
   query => sub {$dbh->selectall_arrayref("select * FROM foo where col = ?", undef, 'dasd'x5000); }
});
```

```
### with my patch: ###
Benchmark: timing 200000 iterations of query...
     query: 11 wallclock secs ( 6.53 usr +  4.45 sys = 10.98 CPU) @ 18208.30/s (n=200000)

### without my patch: ###
Benchmark: timing 200000 iterations of query...
     query: 12 wallclock secs ( 7.16 usr +  4.44 sys = 11.59 CPU) @ 17250.30/s (n=200000)