### PR TITLE
(Makefile.PL): Correct required version of Test::More

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -335,7 +335,7 @@ WriteMakefile(
 		'Tie::Hash'     => 0,
 		'File::Spec'    => (WINLIKE ? '3.27' : '0.82'),
 		'DBI'           => $DBI_required,
-		'Test::More'    => '0.47', # Test::NoWarnings
+		'Test::More'    => '0.82', # Test::NoWarnings
 		'Test::Builder' => '0.86', # Test::NoWarnings
 		( WINLIKE ? (
 			'Win32' => '0.30',
@@ -367,7 +367,7 @@ WriteMakefile(
 			},
 			build_requires => {
 				'File::Spec'          => (WINLIKE ? '3.27' : '0.82'),
-				'Test::More'          => '0.42',
+				'Test::More'          => '0.82',
 				# Bundled in /inc
 				# 'Test::NoWarnings'  => '0.081',
 			},


### PR DESCRIPTION
According to the Perl documentation, the functions note() and
explain() appeared in Test::More version 0.82. Since these functions
are used within the DBD::SQLite tests, the minimum required version
of Test::More needs to be corrected. Without the proper version,
the build fails on Perls earlier than 5.10. For more information:
https://perldoc.perl.org/Test/More.html#COMPATIBILITY