### PR TITLE
Initialize filename variable in sqlite_db_filename()

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1623,7 +1623,7 @@ SV *
 sqlite_db_filename(pTHX_ SV *dbh)
 {
     D_imp_dbh(dbh);
-    const char *filename;
+    const char *filename = NULL;
 
     if (!imp_dbh->db) {
         return &PL_sv_undef;


### PR DESCRIPTION
If sqlite library is too old, filename variable in
sqlite_db_filename() function was never defined. In spite of that the
variable was used in later condition.

This patch fixes it.