### PR TITLE
Die on EOF() method mismatch

### DIFF
--- a/dbdimp_virtual_table.inc
+++ b/dbdimp_virtual_table.inc
@@ -496,8 +496,7 @@ static int perl_vt_Eof(sqlite3_vtab_cursor *pVtabCursor){
     count = call_method ("EOF", G_SCALAR);
     SPAGAIN;
     if (count != 1) {
-        warn("cursor->EOF() method returned %d vals instead of 1", count);
-        SP -= count;
+        croak("cursor->EOF() method returned %d vals instead of 1", count);
     }
     else {
         SV *sv = POPs;     /* need 2 lines, because this doesn't work :        */


### PR DESCRIPTION
perl_vt_Eof() in dbdimp_virtual_table.inc calls EOF() method. If the
call returned an unexpected number of values, perl_vt_Eof() printed
a warning and returned a value of a local variable that was never
initialized.

This patch fixes it by raising an exception instead of printing
a warning.