### PR TITLE
Add DBI SQL_BIT, SQL_BINARY, SQL_VARBINARY and SQL_LONGVARBINARY types as alias for SQLITE_BLOB

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -223,7 +223,11 @@ sqlite_type_from_odbc_type(int type)
         case SQL_REAL:
         case SQL_DOUBLE:
             return SQLITE_FLOAT;
+        case SQL_BIT:
         case SQL_BLOB:
+        case SQL_BINARY:
+        case SQL_VARBINARY:
+        case SQL_LONGVARBINARY:
             return SQLITE_BLOB;
         default:
             return SQLITE_TEXT;

--- a/lib/DBD/SQLite.pm
+++ b/lib/DBD/SQLite.pm
@@ -255,7 +255,12 @@ sub ping {
 sub quote {
     my ($self, $value, $data_type) = @_;
     return "NULL" unless defined $value;
-    if ($data_type and $data_type == DBI::SQL_BLOB) {
+    if (defined $data_type and (
+            $data_type == DBI::SQL_BIT ||
+            $data_type == DBI::SQL_BLOB ||
+            $data_type == DBI::SQL_BINARY ||
+            $data_type == DBI::SQL_VARBINARY ||
+            $data_type == DBI::SQL_LONGVARBINARY)) {
         return q(X') . unpack('H*', $value) . q(');
     }
     $value =~ s/'/''/g;

--- a/t/20_blobs.t
+++ b/t/20_blobs.t
@@ -73,6 +73,19 @@ SCOPE: {
 	ok( $dbh->do("INSERT INTO one VALUES( 5, $quoted_empty )"), 'insert quoted empty string' );
     ok my $quoted_undef = $dbh->quote(undef, SQL_BLOB);
 	ok( $dbh->do("INSERT INTO one VALUES( 6, $quoted_undef )"), 'insert quoted undef' );
+
+
+	ok my $quoted_bit = $dbh->quote($blob, SQL_BIT);
+	ok( $dbh->do("INSERT INTO one VALUES( 7, $quoted_bit )"), 'insert quoted bit' );
+
+	ok my $quoted_binary = $dbh->quote($blob, SQL_BINARY);
+	ok( $dbh->do("INSERT INTO one VALUES( 8, $quoted_binary )"), 'insert quoted binary' );
+
+	ok my $quoted_varbinary = $dbh->quote($blob, SQL_VARBINARY);
+	ok( $dbh->do("INSERT INTO one VALUES( 9, $quoted_varbinary )"), 'insert quoted varbinary' );
+
+	ok my $quoted_longvarbinary = $dbh->quote($blob, SQL_LONGVARBINARY);
+	ok( $dbh->do("INSERT INTO one VALUES( 10, $quoted_longvarbinary )"), 'insert quoted longvarbinary' );
 }
 
 # Now, try SELECT'ing the row out.
@@ -88,6 +101,10 @@ SCOPE: {
 		[ 4, $blob ],
 		[ 5, '' ],
 		[ 6, undef ],
+		[ 7, $blob ],
+		[ 8, $blob ],
+		[ 9, $blob ],
+		[ 10, $blob ],
 	], 'Got the blob back ok' );
 	ok( $sth->finish, '->finish' );
 }


### PR DESCRIPTION
Other DBI drivers use DBI SQL_VARBINARY type for binary data, including
SQLite3 ODBC driver (via DBD::ODBC). So this change allows to use DBI
SQL_VARBINARY type for SQLite3 blob data.