### PR TITLE
Add DBI SQL_BOOLEAN type as alias for SQLITE_INTEGER

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -214,6 +214,7 @@ sqlite_type_from_odbc_type(int type)
     switch(type) {
         case SQL_UNKNOWN_TYPE:
             return SQLITE_NULL;
+        case SQL_BOOLEAN:
         case SQL_INTEGER:
         case SQL_SMALLINT:
         case SQL_TINYINT:


### PR DESCRIPTION
According to SQLite documentation, boolean values are stored as integers:
https://www.sqlite.org/datatype3.html#boolean_datatype