### PR TITLE
Use env var to build with system SQLite

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -129,7 +129,7 @@ SCOPE: {
 # a system sqlite is also sophisticated enough to have a patching system
 # that can change the if ( 0 ) to if ( 1 )
 my ($sqlite_local, $sqlite_base, $sqlite_lib, $sqlite_inc);
-if ( 0 ) {
+if ( $ENV{USE_SYSTEM_SQLITE} ) {
 	require File::Spec;
 	if ( $sqlite_base = (grep(/SQLITE_LOCATION=.*/, @ARGV))[0] ) {
 		$sqlite_base =~ /=(.*)/;


### PR DESCRIPTION
I'm proposing this change for discussion. While our build system does have a patching mechanism, it's easier to specify environment variables than to carry patches between versions. The behavior here is essentially the same in both cases, but this approach gives other folks another mechanism to link against a non-bundled SQLite.