### PR TITLE
Add missing possible table_type values to POD

### DIFF
--- a/lib/DBD/SQLite.pm
+++ b/lib/DBD/SQLite.pm
@@ -1749,7 +1749,8 @@ Returns all tables and schemas (databases) as specified in L<DBI/table_info>.
 The schema and table arguments will do a C<LIKE> search. You can specify an
 ESCAPE character by including an 'Escape' attribute in \%attr. The C<$type>
 argument accepts a comma separated list of the following types 'TABLE',
-'VIEW', 'LOCAL TEMPORARY' and 'SYSTEM TABLE' (by default all are returned).
+'INDEX', 'VIEW', 'TRIGGER', 'LOCAL TEMPORARY' and 'SYSTEM TABLE'
+(by default all are returned).
 Note that a statement handle is returned, and not a direct list of tables.
 
 The following fields are returned:
@@ -1762,8 +1763,8 @@ databases will be in the name given when the database was attached.
 
 B<TABLE_NAME>: The name of the table or view.
 
-B<TABLE_TYPE>: The type of object returned. Will be one of 'TABLE', 'VIEW',
-'LOCAL TEMPORARY' or 'SYSTEM TABLE'.
+B<TABLE_TYPE>: The type of object returned. Will be one of 'TABLE', 'INDEX',
+'VIEW', 'TRIGGER', 'LOCAL TEMPORARY' or 'SYSTEM TABLE'.
 
 =head2 primary_key, primary_key_info
 


### PR DESCRIPTION
I noticed that table_info() returns table_types that are not listed in POD. This copies every possible value from the SQLite documentation. 'LOCAL TEMPORARY' and 'SYSTEM TABLE' are not mentioned there but come from SQLite.pm.

SQLite documention on possible values:
https://www.sqlite.org/schematab.html#interpretation_of_the_schema_table