### PR TITLE
Make ->column_info() also return generated columns

### DIFF
--- a/lib/DBD/SQLite.pm
+++ b/lib/DBD/SQLite.pm
@@ -433,7 +433,7 @@ sub primary_key_info {
             next if defined $table && $table ne '%' && $table ne $tbname;
 
             my $quoted_tbname = $dbh->quote_identifier($tbname);
-            my $t_sth = $dbh->prepare("PRAGMA $quoted_dbname.table_info($quoted_tbname)") or return;
+            my $t_sth = $dbh->prepare("PRAGMA $quoted_dbname.table_xinfo($quoted_tbname)") or return;
             $t_sth->execute or return;
             my @pk;
             while(my $col = $t_sth->fetchrow_hashref) {
@@ -611,7 +611,7 @@ sub foreign_key_info {
                     my $quoted_tb = $dbh->quote_identifier($row->{table});
                     for my $db (@$databases) {
                         my $quoted_db = $dbh->quote_identifier($db->{name});
-                        my $t_sth = $dbh->prepare("PRAGMA $quoted_db.table_info($quoted_tb)") or return;
+                        my $t_sth = $dbh->prepare("PRAGMA $quoted_db.table_xinfo($quoted_tb)") or return;
                         $t_sth->execute or return;
                         my $cols = {};
                         while(my $r = $t_sth->fetchrow_hashref) {
@@ -932,7 +932,7 @@ END_SQL
     # Taken from Fey::Loader::SQLite
     my @cols;
     while ( my ($schema, $table) = $sth_tables->fetchrow_array ) {
-        my $sth_columns = $dbh->prepare(qq{PRAGMA "$schema".table_info("$table")}) or return;
+        my $sth_columns = $dbh->prepare(qq{PRAGMA "$schema".table_xinfo("$table")}) or return;
         $sth_columns->execute or return;
 
         for ( my $position = 1; my $col_info = $sth_columns->fetchrow_hashref; $position++ ) {

--- a/t/35_table_info.t
+++ b/t/35_table_info.t
@@ -121,6 +121,18 @@ my $table4_info = [undef, 'db3', 'one', 'TABLE', undef, 'CREATE TABLE one (
     name CHAR (64) NOT NULL
 )'];
 
+# Create a table with generated columns
+ok( $dbh->do(<<'END_SQL'), 'CREATE TABLE generated_columns' );
+CREATE TABLE generated_columns (
+    id INTEGER PRIMARY KEY NOT NULL,
+    nextid GENERATED ALWAYS AS (id+1)
+)
+END_SQL
+my $table_generated_info = [undef, 'main', 'generated_columns', 'TABLE', undef, 'CREATE TABLE generated_columns (
+    id INTEGER PRIMARY KEY NOT NULL,
+    nextid GENERATED ALWAYS AS (id+1)
+)'];
+
 # Get table_info for both tables named "one"
 $info = $dbh->table_info(undef, undef, 'one')->fetchall_arrayref;
 is_deeply $info, [$table4_info, $table1_info], 'Correct table_info for both tables named "one"';
@@ -131,7 +143,7 @@ is_deeply $info, \@systable_info, 'Correct table_info for the system tables';
 
 # Get table_info for all tables
 $info = $dbh->table_info()->fetchall_arrayref;
-is_deeply $info, [$table2_info, @systable_info, $table4_info, $table3_info, $table1_info],
+is_deeply $info, [$table2_info, @systable_info, $table4_info, $table3_info, $table_generated_info, $table1_info ],
     'Correct table_info for all tables';
 
 #use Data::Dumper;


### PR DESCRIPTION
Before this change, generated columns were not returned by ->column_info():

CREATE TABLE generated_columns (
    id INTEGER PRIMARY KEY NOT NULL,
    nextid GENERATED ALWAYS AS (id+1)
)

never showed the column "nextid".

The cause was that "PRAGMA table_info()" was used to fetch the information. PRAGMA table_info() does not return "hidden" columns like generated columns.

This patch switches to "PRAGMA table_xinfo()", which also returns the generated columns and adds tests.